### PR TITLE
Use new method to avoid deprecation warning of pypandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ from setuptools.extension import Extension
 readme = 'README.md'
 
 try:
-    from pypandoc import convert
-    long_description = convert(readme, 'rst')
+    from pypandoc import convert_file
+    long_description = convert_file(readme, 'rst')
 except ImportError:
     if os.name == 'nt':
         if sys.version_info.major == 2:


### PR DESCRIPTION
`DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated. Use 'convert_file()'  or 'convert_text()'.`